### PR TITLE
chore: bump deno version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.1.x
 
       - name: Install Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
### TL;DR
Upgraded Deno setup action and version in GitHub workflow

### What changed?
- Updated `denoland/setup-deno` action from v1 to v2
- Updated Deno version from `v1.x` to `v2.1.x`
