### PR TITLE
fix: pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages: []
+
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@prisma/client'


### PR DESCRIPTION
## Description

This simple pr should make the deploy job pass, tested [here](https://github.com/thomas-mauran/variants-world/actions/runs/21071869028/job/60603415055)

#135 

It's passing the install dependencies step now, seems like it's stuck at prisma I'm not sure if this is still used since the repo seem to have been migrated from supabase prisma to convex

